### PR TITLE
Social Logins and other minor fixes/additons

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 A web application that allows users to maintain a virtualization of their fridge and get recipe suggests or search for relevant recipes.
 This is a updated and mostly rewritten version of a group project from CSC309 at the University of Toronto by Linda Zhang, Jesse Jaura and David Wahrhaftig
 https://nomten.herokuapp.com/
-Sample User: JonSnow Pwd: 12345
+Sample User: jonsnow@email.com Pwd: 12345
 IMPORTANT: If you are registering a new user I would need to white list your email in mailgun first for you to be able to recieve the registration email and also the emails for password reset. Please email me at lindamayzhang@gmail.com if you wish to have your email white listed. 
 
 NomTen: A personalized online culinary assistant

--- a/models/users.js
+++ b/models/users.js
@@ -4,12 +4,17 @@ var passportLocalMongoose = require("passport-local-mongoose");
 mongoose.Promise = global.Promise;
 
 var UserSchema = mongoose.Schema({
-  username: {type: String, unique: true, required: true},
+  username: {type: String, required: true},
   email:{type: String, unique: true, required: true},
   emailConfirmed: Boolean,
   confirmToken: String,
   confirmExpires: Date,
   password: String,
+  local: Boolean,
+  facebook: {
+    id: String,
+    token: String
+  },
   resetPasswordToken: String,
   resetPasswordExpires: Date,
   proteinList: [String],
@@ -19,5 +24,5 @@ var UserSchema = mongoose.Schema({
   fruitList: [String],
   miscList:[String],
 });
-UserSchema.plugin(passportLocalMongoose);
+UserSchema.plugin(passportLocalMongoose, {usernameField: 'email'});
 module.exports = mongoose.model("User", UserSchema);

--- a/models/users.js
+++ b/models/users.js
@@ -15,6 +15,10 @@ var UserSchema = mongoose.Schema({
     id: String,
     token: String
   },
+  google: {
+    id: String,
+    token: String
+  },
   resetPasswordToken: String,
   resetPasswordExpires: Date,
   proteinList: [String],

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "nodemailer": "^4.6.3",
     "nodemailer-mailgun-transport": "^1.3.6",
     "passport": "^0.4.0",
+    "passport-facebook": "^2.1.1",
     "passport-local": "^1.0.0",
     "passport-local-mongoose": "^5.0.0",
     "request": "^2.85.0"

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "nodemailer-mailgun-transport": "^1.3.6",
     "passport": "^0.4.0",
     "passport-facebook": "^2.1.1",
+    "passport-google-oauth": "^1.0.0",
     "passport-local": "^1.0.0",
     "passport-local-mongoose": "^5.0.0",
     "request": "^2.85.0"

--- a/public/scripts/landing.js
+++ b/public/scripts/landing.js
@@ -1,6 +1,0 @@
-//fade flash message after 3 seconds
-$(document).ready(function(){
-  if($(".alert") != null){
-    $(".alert").animate({opacity: 0}, 6000);
-  }
-})

--- a/server.js
+++ b/server.js
@@ -24,7 +24,6 @@ var indexRoutes      = require("./routes/index"),
     ingredientRoutes = require("./routes/ingredients"),
     recipeRoutes     = require("./routes/recipe");
 
-/*
 app.use((req, res, next) => {
   	if (req.header("x-forwarded-proto") !== "https") {
     	res.redirect(`https://${req.header('host')}${req.url}`);
@@ -32,7 +31,6 @@ app.use((req, res, next) => {
     	next();
   	}
 });
-*/
 
 app.set("view engine", "ejs");
 app.use(bodyParser.urlencoded({extended: true}));

--- a/server.js
+++ b/server.js
@@ -21,6 +21,7 @@ var indexRoutes      = require("./routes/index"),
     ingredientRoutes = require("./routes/ingredients"),
     recipeRoutes     = require("./routes/recipe");
 
+
 app.set("view engine", "ejs");
 app.use(bodyParser.urlencoded({extended: true}));
 app.use(bodyParser.json());

--- a/server.js
+++ b/server.js
@@ -21,6 +21,13 @@ var indexRoutes      = require("./routes/index"),
     ingredientRoutes = require("./routes/ingredients"),
     recipeRoutes     = require("./routes/recipe");
 
+app.use((req, res, next) => {
+  	if (req.header("x-forwarded-proto") !== "https") {
+    	res.redirect(`https://${req.header('host')}${req.url}`);
+  	}else {
+    	next();
+  	}
+});
 
 app.set("view engine", "ejs");
 app.use(bodyParser.urlencoded({extended: true}));

--- a/server.js
+++ b/server.js
@@ -12,14 +12,17 @@ var express        = require("express"),
     nodemailer     = require("nodemailer"),
     mg             = require("nodemailer-mailgun-transport"),
     crypto         = require("crypto"),
-    User           = require("./models/users");
-    schedule      = require("node-schedule")
+    User           = require("./models/users"),
+    schedule      = require("node-schedule"),
+    facebookPassport = require('passport-facebook'), 
+    FacebookStrategy = require('passport-facebook').Strategy;
 require('dotenv').config();
 
 //require routes
 var indexRoutes      = require("./routes/index"),
     ingredientRoutes = require("./routes/ingredients"),
     recipeRoutes     = require("./routes/recipe");
+
 
 app.use((req, res, next) => {
   	if (req.header("x-forwarded-proto") !== "https") {
@@ -28,6 +31,7 @@ app.use((req, res, next) => {
     	next();
   	}
 });
+
 
 app.set("view engine", "ejs");
 app.use(bodyParser.urlencoded({extended: true}));
@@ -52,6 +56,7 @@ passport.use(new LocalStrategy(User.authenticate()));
 passport.serializeUser(User.serializeUser());
 passport.deserializeUser(User.deserializeUser());
 
+
 app.use(function(req, res, next){
   res.locals.currentUser = req.user;
   res.locals.error = req.flash("error");
@@ -63,6 +68,95 @@ app.use(function(req, res, next){
 app.use("/", indexRoutes);
 app.use("/", ingredientRoutes);
 app.use("/", recipeRoutes);
+
+passport.use(new FacebookStrategy({
+    clientID: process.env.FB_APP_ID,
+    clientSecret: process.env.FB_APP_SECRET,
+    callbackURL: "http://nomthirteen.herokuapp.com/auth/facebook/callback",
+    profileFields: ['name', 'emails'],
+    passReqToCallback : true
+
+}, function(req, accessToken, refreshToken, profile, cb) {
+
+  // If user is not logged in
+  if (!req.user) {
+    User.findOne({'facebook.id' : profile.id}, function(error, user) {
+      if (error) {
+        cb(error);
+      }
+
+      // User already has acc on db
+      if (user) {
+        return cb(null, user);
+      } else {
+        User.findOne({'email': profile.emails[0].value}, function(error, user) {
+        
+        if (error) {
+          cb(error);
+        }
+
+        // email already in use
+        if (user){
+          req.flash('error', 'Email associated with Facebook account already in use. Please log in first and then connect Facebook account.');
+          cb(null);
+        } else {
+
+        var newUser = new User({
+        username: profile.name.givenName,
+        email: profile.emails[0].value,
+        emailConfirmed: true,
+        facebook: {
+          id: profile.id,
+          token: accessToken
+        }});
+        newUser.save(function(error) {
+          if (error) {
+            console.log(error);
+          }
+          return cb(null, newUser);
+          })
+        }
+        });
+      }
+    })
+  } else { 
+  // User is logged in so link fb account
+    var user = req.user;
+    user.facebook.id = profile.id;
+    user.facebook.token = accessToken;
+    user.save(function(error) {
+      if (error) {
+        console.log(error);
+      }
+      return cb(null, user);
+    })
+
+  }
+}));
+
+app.get('/auth/facebook', passport.authenticate('facebook', {scope: 'email'}));
+
+app.get('/auth/facebook/callback',
+    passport.authenticate('facebook', {
+        successRedirect: '/users/fb',
+        failureRedirect: '/'
+    }));
+
+app.get('/link/facebook', passport.authorize('facebook', {scope: 'email'}));
+
+app.get('/link/facebook/callback',
+    passport.authorize('facebook', {
+        successRedirect: '/users/fb',
+        failureRedirect: '/'
+    }));
+
+app.get('/unlink/facebook', function(req, res) {
+  var user = req.user;
+  user.facebook = undefined;
+  user.save(function(error){
+    res.redirect('back');
+  })
+})
 
 // Clean database every Monday at 3 am
 var rule = new schedule.RecurrenceRule();

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -12,7 +12,6 @@
     <link rel="stylesheet" href="/stylesheets/landing.css">
     <link href="https://fonts.googleapis.com/css?family=Pacifico" rel="stylesheet">
     <script src="https://cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.3/modernizr.min.js" type="text/javascript" async></script>
-    <script src="/scripts/landing.js" charset="utf-8"></script>
   </head>
   <body>
     <nav class="navbar navbar-default">
@@ -30,7 +29,20 @@
             <% if(!currentUser){ %>
             <li><a href="/register">Sign Up</a></li>
             <% } else { %>
-            <li><a href="#"><i class="fa fa-user" ></i> <%=currentUser.username%></a></li>
+            <li><a class="btn dropdown-toggle" href="#" role="button" id="dropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><i class="fa fa-user" ></i> <%=currentUser.username%></a>
+            <div class="dropdown-menu" aria-labelledby="dropdownMenuLink">
+              <% if (currentUser.facebook.token) { %>
+                <% if (currentUser.local) { %>
+                <a href="/unlink/facebook" class="btn btn-primary"><span class="fa fa-facebook"></span> Unlink Facebook</a>
+                <% } else { %>
+                <a href="/unlink/facebook" class="btn btn-primary disabled"><span class="fa fa-facebook"></span> Unlink Facebook</a>
+                <% } %>
+              <% } else { %>
+              <a href="/link/facebook" class="btn btn-primary"><span class="fa fa-facebook"></span> Connect Facebook</a>
+            <% } %>
+              <a href="/update_password" class="btn btn-warning"> Change Password</a>
+            </div>
+            </li>
             <li><a href="/logout">Logout</a></li>
             <% } %>
           </ul>
@@ -38,31 +50,32 @@
       </div>
     </nav>
 
-
     <div class="container">
       <% if(error && error.length > 0){ %>
-      <div class="alert alert-danger" role="alert">
-        <%= error %>
+      <div class="alert alert-danger" role="alert" style="position: sticky; z-index: 100;" >
+        <%- error %>
       </div>
       <% } %>
       <% if(success && success.length > 0){ %>
-      <div class="alert alert-success" role="alert">
-        <%= success %>
+      <div class="alert alert-success" role="alert" style="position: sticky; z-index: 100;">
+        <%- success %>
       </div>
       <% } %>
     </div>
+
     <div class="container" id="landing-header">
       <h1>Welcome to <span>NomTen</span>!</h1>
       <% if(!currentUser){ %>
       <div id="loginPosition" class="container col-sm-12">
-        <form action="/login" method="POST" class="form-inline">
-          <div class="form-group" id=login>
-            <input type="text" name="username" placeholder="username" class="from-control input-sm">
+        <form action="/login" method="POST" class="form-group">
+          <div class="form-inline" id=login>
+            <input type="text" name="username" placeholder="email" class="from-control input-sm">
             <input type="password" name="password" placeholder="password" class="from-control input-sm">
+            <input type="submit" value="Login" class="btn btn-default btn-sm">
           </div>
-          <input type="submit" value="Login" class="btn btn-default btn-sm">
-        </form>
-        <a id=reset href="/forgot">Forgot Password?</a>
+          <a href="/auth/facebook" class="btn btn-primary"><span class="fa fa-facebook"></span> Login with Facebook</a>
+          <a id=reset href="/forgot" class="btn btn-warning btn-sm">Forgot Password?</a>
+      </form>
       </div>
       <% } else { %>
       <a id="showPofile" class="btn btn-lg" href="/users/<%=currentUser.username%>">View Fridge</a>

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -27,7 +27,6 @@
         <div class="collapse navbar-collapse" id="myNavbar2">
           <ul class="nav navbar-nav navbar-right">
             <% if(!currentUser){ %>
-            <li><a href="/">Sign In</a></li>
             <li><a href="/register">Sign Up</a></li>
             <% } else { %>
             <li><a href="/users/home"><i class="fa fa-user" ></i> <%=currentUser.username%></a></li>

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -27,20 +27,36 @@
         <div class="collapse navbar-collapse" id="myNavbar2">
           <ul class="nav navbar-nav navbar-right">
             <% if(!currentUser){ %>
+            <li><a href="/">Sign In</a></li>
             <li><a href="/register">Sign Up</a></li>
             <% } else { %>
-            <li><a class="btn dropdown-toggle" href="#" role="button" id="dropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><i class="fa fa-user" ></i> <%=currentUser.username%></a>
+            <li><a href="/"><i class="fa fa-user" ></i> <%=currentUser.username%></a></li>
+            <li>
+            <a class="btn dropdown-toggle" href="#" role="button" id="dropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><i class="fa fa-cog" ></i> Settings</a>
             <div class="dropdown-menu" aria-labelledby="dropdownMenuLink">
               <% if (currentUser.facebook.token) { %>
-                <% if (currentUser.local) { %>
+                <% if (currentUser.local || currentUser.toObject().google) { %>
                 <a href="/unlink/facebook" class="btn btn-primary"><span class="fa fa-facebook"></span> Unlink Facebook</a>
                 <% } else { %>
                 <a href="/unlink/facebook" class="btn btn-primary disabled"><span class="fa fa-facebook"></span> Unlink Facebook</a>
                 <% } %>
               <% } else { %>
               <a href="/link/facebook" class="btn btn-primary"><span class="fa fa-facebook"></span> Connect Facebook</a>
-            <% } %>
+              <% } %>
+              <% if (currentUser.google.token) { %>
+                <% if (currentUser.local || currentUser.toObject().facebook) { %>
+                <a href="/unlink/google" class="btn btn-danger"><span class="fa fa-google-plus"></span> Unlink Google+</a>
+                <% } else { %>
+                <a href="/unlink/google" class="btn btn-danger disabled"><span class="fa fa-google-plus"></span> Unlink Google+</a>
+                <% } %>
+              <% } else { %>
+              <a href="/link/google" class="btn btn-danger"><span class="fa fa-google-plus"></span> Connect Google+</a>
+              <% } %>
+              <% if (currentUser.local) { %>
               <a href="/update_password" class="btn btn-warning"> Change Password</a>
+              <% } else { %>
+              <a href="/update_password" class="btn btn-warning"> Update Password</a>
+              <% } %>
             </div>
             </li>
             <li><a href="/logout">Logout</a></li>
@@ -74,6 +90,7 @@
             <input type="submit" value="Login" class="btn btn-default btn-sm">
           </div>
           <a href="/auth/facebook" class="btn btn-primary"><span class="fa fa-facebook"></span> Login with Facebook</a>
+          <a href="/auth/google" class="btn btn-danger"><span class="fa fa-google-plus"></span> Login with Google+</a>
           <a id=reset href="/forgot" class="btn btn-warning btn-sm">Forgot Password?</a>
       </form>
       </div>

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -30,7 +30,7 @@
             <li><a href="/">Sign In</a></li>
             <li><a href="/register">Sign Up</a></li>
             <% } else { %>
-            <li><a href="/"><i class="fa fa-user" ></i> <%=currentUser.username%></a></li>
+            <li><a href="/users/home"><i class="fa fa-user" ></i> <%=currentUser.username%></a></li>
             <li>
             <a class="btn dropdown-toggle" href="#" role="button" id="dropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><i class="fa fa-cog" ></i> Settings</a>
             <div class="dropdown-menu" aria-labelledby="dropdownMenuLink">

--- a/views/partials/header.ejs
+++ b/views/partials/header.ejs
@@ -35,10 +35,12 @@
           <li><a href="/">Sign In</a></li>
           <li><a href="/register">Sign Up</a></li>
           <% } else { %>
-          <li><a class="btn dropdown-toggle" href="#" role="button" id="dropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><i class="fa fa-user" ></i> <%=currentUser.username%></a>
+          <li><a href="/"><i class="fa fa-user" ></i> <%=currentUser.username%></a></li>
+          <li>
+          <a class="btn dropdown-toggle" href="#" role="button" id="dropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><i class="fa fa-cog" ></i> Settings</a>
           <div class="dropdown-menu" aria-labelledby="dropdownMenuLink">
             <% if (currentUser.facebook.token) { %>
-              <% if (currentUser.local) { %>
+              <% if (currentUser.local || currentUser.toObject().google) { %>
               <a href="/unlink/facebook" class="btn btn-primary"><span class="fa fa-facebook"></span> Unlink Facebook</a>
               <% } else { %>
               <a href="/unlink/facebook" class="btn btn-primary disabled"><span class="fa fa-facebook"></span> Unlink Facebook</a>
@@ -46,8 +48,22 @@
             <% } else { %>
             <a href="/link/facebook" class="btn btn-primary"><span class="fa fa-facebook"></span> Connect Facebook</a>
             <% } %>
+            <% if (currentUser.google.token) { %>
+              <% if (currentUser.local || currentUser.toObject().facebook) { %>
+              <a href="/unlink/google" class="btn btn-danger"><span class="fa fa-google-plus"></span> Unlink Google+</a>
+              <% } else { %>
+              <a href="/unlink/google" class="btn btn-danger disabled"><span class="fa fa-google-plus"></span> Unlink Google+</a>
+              <% } %>
+            <% } else { %>
+            <a href="/link/google" class="btn btn-danger"><span class="fa fa-google-plus"></span> Connect Google+</a>
+            <% } %>
+            <% if (currentUser.local) { %>
             <a href="/update_password" class="btn btn-warning"> Change Password</a>
-          </div></li>
+            <% } else { %>
+            <a href="/update_password" class="btn btn-warning"> Update Password</a>
+            <% } %>
+          </div>
+          </li>
           <li><a href="/logout">Logout</a></li>
           <% } %>
         </ul>

--- a/views/partials/header.ejs
+++ b/views/partials/header.ejs
@@ -35,7 +35,19 @@
           <li><a href="/">Sign In</a></li>
           <li><a href="/register">Sign Up</a></li>
           <% } else { %>
-          <li><a href="#"><i class="fa fa-user" ></i> <%=currentUser.username%></a></li>
+          <li><a class="btn dropdown-toggle" href="#" role="button" id="dropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><i class="fa fa-user" ></i> <%=currentUser.username%></a>
+          <div class="dropdown-menu" aria-labelledby="dropdownMenuLink">
+            <% if (currentUser.facebook.token) { %>
+              <% if (currentUser.local) { %>
+              <a href="/unlink/facebook" class="btn btn-primary"><span class="fa fa-facebook"></span> Unlink Facebook</a>
+              <% } else { %>
+              <a href="/unlink/facebook" class="btn btn-primary disabled"><span class="fa fa-facebook"></span> Unlink Facebook</a>
+              <% } %>
+            <% } else { %>
+            <a href="/link/facebook" class="btn btn-primary"><span class="fa fa-facebook"></span> Connect Facebook</a>
+            <% } %>
+            <a href="/update_password" class="btn btn-warning"> Change Password</a>
+          </div></li>
           <li><a href="/logout">Logout</a></li>
           <% } %>
         </ul>
@@ -46,12 +58,12 @@
   <div class="container">
     <% if(error && error.length > 0){ %>
     <div class="alert alert-danger" role="alert">
-      <%= error %>
+      <%- error %>
     </div>
     <% } %>
     <% if (success && success.length > 0){%>
     <div class="alert alert-success" role="alert">
-      <%= success %>
+      <%- success %>
     </div>
     <% } %>
   </div>

--- a/views/partials/header.ejs
+++ b/views/partials/header.ejs
@@ -35,7 +35,7 @@
           <li><a href="/">Sign In</a></li>
           <li><a href="/register">Sign Up</a></li>
           <% } else { %>
-          <li><a href="/"><i class="fa fa-user" ></i> <%=currentUser.username%></a></li>
+          <li><a href="/users/home"><i class="fa fa-user" ></i> <%=currentUser.username%></a></li>
           <li>
           <a class="btn dropdown-toggle" href="#" role="button" id="dropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><i class="fa fa-cog" ></i> Settings</a>
           <div class="dropdown-menu" aria-labelledby="dropdownMenuLink">

--- a/views/profile.ejs
+++ b/views/profile.ejs
@@ -35,11 +35,12 @@
           <li><a href="/">Sign In</a></li>
           <li><a href="/register">Sign Up</a></li>
           <% } else { %>
+          <li><a href="/"><i class="fa fa-user" ></i> <%=currentUser.username%></a></li>
           <li>
-          <a class="btn dropdown-toggle" href="#" role="button" id="dropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><i class="fa fa-user" ></i> <%=currentUser.username%></a>
+          <a class="btn dropdown-toggle" href="#" role="button" id="dropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><i class="fa fa-cog" ></i> Settings</a>
           <div class="dropdown-menu" aria-labelledby="dropdownMenuLink">
             <% if (currentUser.facebook.token) { %>
-              <% if (currentUser.local) { %>
+              <% if (currentUser.local || currentUser.toObject().google) { %>
               <a href="/unlink/facebook" class="btn btn-primary"><span class="fa fa-facebook"></span> Unlink Facebook</a>
               <% } else { %>
               <a href="/unlink/facebook" class="btn btn-primary disabled"><span class="fa fa-facebook"></span> Unlink Facebook</a>
@@ -47,7 +48,20 @@
             <% } else { %>
             <a href="/link/facebook" class="btn btn-primary"><span class="fa fa-facebook"></span> Connect Facebook</a>
             <% } %>
+            <% if (currentUser.google.token) { %>
+              <% if (currentUser.local || currentUser.toObject().facebook) { %>
+              <a href="/unlink/google" class="btn btn-danger"><span class="fa fa-google-plus"></span> Unlink Google+</a>
+              <% } else { %>
+              <a href="/unlink/google" class="btn btn-danger disabled"><span class="fa fa-google-plus"></span> Unlink Google+</a>
+              <% } %>
+            <% } else { %>
+            <a href="/link/google" class="btn btn-danger"><span class="fa fa-google-plus"></span> Connect Google+</a>
+            <% } %>
+            <% if (currentUser.local) { %>
             <a href="/update_password" class="btn btn-warning"> Change Password</a>
+            <% } else { %>
+            <a href="/update_password" class="btn btn-warning"> Update Password</a>
+            <% } %>
           </div>
           </li>
           <li><a href="/logout">Logout</a></li>

--- a/views/profile.ejs
+++ b/views/profile.ejs
@@ -35,7 +35,21 @@
           <li><a href="/">Sign In</a></li>
           <li><a href="/register">Sign Up</a></li>
           <% } else { %>
-          <li><a href="#"><i class="fa fa-user" ></i> <%=currentUser.username%></a></li>
+          <li>
+          <a class="btn dropdown-toggle" href="#" role="button" id="dropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><i class="fa fa-user" ></i> <%=currentUser.username%></a>
+          <div class="dropdown-menu" aria-labelledby="dropdownMenuLink">
+            <% if (currentUser.facebook.token) { %>
+              <% if (currentUser.local) { %>
+              <a href="/unlink/facebook" class="btn btn-primary"><span class="fa fa-facebook"></span> Unlink Facebook</a>
+              <% } else { %>
+              <a href="/unlink/facebook" class="btn btn-primary disabled"><span class="fa fa-facebook"></span> Unlink Facebook</a>
+              <% } %>
+            <% } else { %>
+            <a href="/link/facebook" class="btn btn-primary"><span class="fa fa-facebook"></span> Connect Facebook</a>
+            <% } %>
+            <a href="/update_password" class="btn btn-warning"> Change Password</a>
+          </div>
+          </li>
           <li><a href="/logout">Logout</a></li>
           <% } %>
         </ul>

--- a/views/profile.ejs
+++ b/views/profile.ejs
@@ -35,7 +35,7 @@
           <li><a href="/">Sign In</a></li>
           <li><a href="/register">Sign Up</a></li>
           <% } else { %>
-          <li><a href="/"><i class="fa fa-user" ></i> <%=currentUser.username%></a></li>
+          <li><a href="/users/home"><i class="fa fa-user" ></i> <%=currentUser.username%></a></li>
           <li>
           <a class="btn dropdown-toggle" href="#" role="button" id="dropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><i class="fa fa-cog" ></i> Settings</a>
           <div class="dropdown-menu" aria-labelledby="dropdownMenuLink">

--- a/views/register.ejs
+++ b/views/register.ejs
@@ -3,7 +3,7 @@
   <h1>Sign Up</h1>
   <form action="/register" method="POST">
     <div class="form-group">
-      <input class="form-control" type="text" name="username" placeholder="username">
+      <input class="form-control" type="text" name="username" placeholder="Name">
     </div>
     <div class="form-group">
       <input class="form-control" type="email" name="email" placeholder="email">

--- a/views/update.ejs
+++ b/views/update.ejs
@@ -1,11 +1,17 @@
 <% include partials/header %>
 <div class="container">
   <div class="col-md-8">
-    <h1>Reset Password</h1>
-    <form action="/reset/<%=token%>" method="POST">
+    <h1>Update Password</h1>
+    <form action="/update_password" method="POST">
+      <% if (currentUser.local) { %>
+      <div class="form-group">
+        <label for="exampleInputEmail1">Old Password</label>
+        <input class="form-control" type="password" name="oldPassword" autofocus="autofocus" placeholder="old password">
+      </div>
+      <% } %>
       <div class="form-group">
         <label for="exampleInputEmail1">New Password</label>
-        <input class="form-control" type="password" name="password" autofocus="autofocus" placeholder="new password">
+        <input class="form-control" type="password" name="newPassword" autofocus="autofocus" placeholder="new password">
       </div>
       <div class="form-group">
         <label for="exampleInputEmail1">Confirm Password</label>


### PR DESCRIPTION
Changelog:
- implemented FB and G+ social logins
- added https redirection
- fixed bug where expired unconfirmed user not removed from db during login
- changed <%= to <%- in header ejs to allow html in flash messages (such as adding links to the message using an <a> tag)
- if email not confirmed during pass reset, a link to resend confirm email will show
- login users with email instead of username, usernames no longer have to be unique, only used to give a readable name to profile. FB/G+ logins will grab name from profile and set that as the username.
- removed fade out animation for alert so that resend link is clickable
- clicking the settings icon lets you access settings to link/unlink fb, google, and update password
- user icon redirs to user profile now